### PR TITLE
const qualifier needed to compile on OSX 10.11.2

### DIFF
--- a/gsoap/stdsoap2.cpp
+++ b/gsoap/stdsoap2.cpp
@@ -4158,7 +4158,7 @@ again:
           { X509_EXTENSION *ext = X509_get_ext(peer, i);
             const char *ext_str = OBJ_nid2sn(OBJ_obj2nid(X509_EXTENSION_get_object(ext)));
             if (ext_str && !strcmp(ext_str, "subjectAltName"))
-            { X509V3_EXT_METHOD *meth = X509V3_EXT_get(ext);
+            { const X509V3_EXT_METHOD *meth = X509V3_EXT_get(ext);
               void *ext_data;
 #if (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
               const unsigned char *data;


### PR DESCRIPTION
Hi, 
I was unable to compile gSoap on OSX: a const qualifier was missing.
Hope it helps,

Max
